### PR TITLE
Master DA index

### DIFF
--- a/CopyGDB.py
+++ b/CopyGDB.py
@@ -1,0 +1,7 @@
+from arcpy import Copy_management
+
+#Set local variables
+in_data= "P:/Linear Asset Management Program/Water Sewer Projects Initiated/03 GIS Data/Hydraulic Studies"
+out_data = "C:/Users/christine.brown/Desktop/SSHA/Small_Sewer_Capacity.gdb"
+#execute
+Copy_management(in_data, out_data)

--- a/HHCalculations.py
+++ b/HHCalculations.py
@@ -255,7 +255,7 @@ def run_hydrology(project_id, study_sewers, study_areas, study_area_id=None):
 		C = drainage_area.getValue("Runoff_Coefficient")
 		#C = Working_RC_Calcs.getC(study_area_id, project_id)
 		print C
-		A = drainage_area.getValue("SHAPE_Area") / 43560
+		A = drainage_area.getValue("SHAPE.STArea()") / 43560
 		I = 116 / ( tc + 17)
 		peak_runoff =  C * I * A
 

--- a/HHCalculations.py
+++ b/HHCalculations.py
@@ -3,11 +3,10 @@
 import arcpy
 from arcpy import env
 import math
-import Working_RC_Calcs
 import ssha_tools
 import utils
 import os
-import hhcalcs
+
 
 # ====================
 # HYDRUALIC EQUATIONS

--- a/HHCalculations.py
+++ b/HHCalculations.py
@@ -1,7 +1,6 @@
 #hydraulic and hydrologic calculation tools
 
 import arcpy
-from arcpy import env
 import math
 import ssha_tools
 import utils

--- a/associate_sewers.py
+++ b/associate_sewers.py
@@ -20,6 +20,9 @@ def associate_sewers_to_area(project_id, from_sewers, study_sewers, study_areas)
     #uniqs = str(tuple(unique_values(study_sewers, "StudyArea_ID"))).replace("u", "")
 	uniqs = utils.unique_values(study_sewers, "StudyArea_ID")
 
+	#check to ensure that there are no pipes with StudyArea_ID = <Null>
+	if 'None' in uniqs:
+		arcpy.AddWarning("Sewer in StudiedSewers where StudyArea_ID is Null!")
 	#create random names for temporary DA and sewer layers
 	DAs_temp = "DA_" + utils.random_alphanumeric()
 	sewers = "sewers_" + utils.random_alphanumeric()

--- a/ssha_tools.py
+++ b/ssha_tools.py
@@ -59,20 +59,26 @@ def updateDAIndex (project_id, study_areas, study_area_indices):
 	tempData = arcpy.env.scratchGDB
 
 	#Set file path for temporary feature class in scratchGDB
-	index_featureclass = os.path.join(tempData, "DA_" + project_id)
+	index_featureclass_path = os.path.join(tempData, "DA_" + project_id)
 
 	#check if index already exists, delete if necessary
-	if arcpy.Exists(index_featureclass):
+	if arcpy.Exists(index_featureclass_path):
 		arcpy.AddMessage('{} index exists, overwriting...'.format(project_id))
-		arcpy.Delete_management(index_featureclass)
+		arcpy.Delete_management(index_featureclass_path)
 
 	where = "Project_ID = " + project_id
 	layer_name = "DA_" + project_id
 
-	#arcpy.MakeFeatureLayer_management(study_areas, index_featureclass, where_clause = where)
 	#create feature class from small sewer drainage area and store temporarily in the default gdb
-	arcpy.FeatureClassToFeatureClass_conversion(study_areas, tempData, layer_name, where_clause = where)
+	index_featureclass = arcpy.FeatureClassToFeatureClass_conversion(study_areas, tempData, layer_name, where_clause = where)
+
+	#Attempting to match schemas
+	#utils.match_schemas(study_area_indices, index_featureclass, delete_fields=True)
+
+	#Manually deleting dropFields causing issues with schema match. Temp fix need to go back and fix properly.
+	dropFields = ["SHAPE_STArea__", "SHAPE_STLength__"]
+	arcpy.DeleteField_management(index_featureclass, dropFields)
 	#append temporary feature class to the DA_Master feature class
 	arcpy.Append_management(index_featureclass, study_area_indices, "TEST")
 	#delete the feature class in the default gdb
-	#arcpy.Delete_management(index_featureclass)
+	arcpy.Delete_management(index_featureclass)

--- a/ssha_tools.py
+++ b/ssha_tools.py
@@ -5,6 +5,7 @@ import HHCalculations
 import utils
 import os
 
+default_env = "C:/Users/christine.brown/Desktop/SSHA/Small_Sewer_Capacity/Default.gdb"
 
 def trace_upstream(startid, table=r"Small_Sewer_Drainage_Areas",
 					return_field = 'StudyArea_ID',
@@ -56,14 +57,18 @@ def updateDAIndex (project_id, study_areas, study_area_indices):
 	"""
 
 	#check if index already exists, delete if necessary
-	index_layer = os.path.join(study_area_indices, "DA_" + project_id)
-	if arcpy.Exists(index_layer):
+	index_featureclass = os.path.join(default_env, "/DA_" + project_id)
+	if arcpy.Exists(index_featureclass):
 		arcpy.AddMessage('{} index exists, overwriting...'.format(project_id))
-		arcpy.Delete_management(index_layer)
+		arcpy.Delete_management(index_featureclass)
 
 	where = "Project_ID = " + project_id
 	layer_name = "DA_" + project_id
 
-	arcpy.MakeFeatureLayer_management(study_areas, index_layer, where_clause = where)
-	arcpy.FeatureClassToFeatureClass_conversion(index_layer, study_area_indices, layer_name)
-	arcpy.Delete_management(index_layer)
+	#arcpy.MakeFeatureLayer_management(study_areas, index_featureclass, where_clause = where)
+	#create feature class from small sewer drainage area and store temporarily in the default gdb
+	arcpy.FeatureClassToFeatureClass_conversion(study_areas, default_env, layer_name, where_clause = where)
+	#append temporary feature class to the DA_Master feature class
+	arcpy.Append_management(index_featureclass, study_area_indices, "TEST")
+	#delete the feature class in the default gdb
+	#arcpy.Delete_management(index_featureclass)

--- a/ssha_tools.py
+++ b/ssha_tools.py
@@ -1,12 +1,11 @@
 import arcpy
 import random
-import Working_RC_Calcs
 import HHCalculations
 import utils
 import os
 
-workspace = "C:/Users/christine.brown/Desktop/SSHA/Small_Sewer_Capacity/Default.gdb"
-arcpy.env.workspace = workspace
+# workspace = "C:/Users/christine.brown/Desktop/SSHA/Small_Sewer_Capacity/Default.gdb"
+# arcpy.env.workspace = workspace
 
 def trace_upstream(startid, table=r"Small_Sewer_Drainage_Areas",
 					return_field = 'StudyArea_ID',
@@ -56,10 +55,13 @@ def updateDAIndex (project_id, study_areas, study_area_indices):
 	feature class. This compainion feature class is used for Data Driven Pages
 	functionality.
 	"""
+	#Use scratchGDB environment to write intermediate data
+	tempData = arcpy.env.scratchGDB
+
+	#Set file path for temporary feature class in scratchGDB
+	index_featureclass = os.path.join(tempData, "DA_" + project_id)
 
 	#check if index already exists, delete if necessary
-	index_featureclass = os.path.join(workspace, "DA_" + project_id)
-
 	if arcpy.Exists(index_featureclass):
 		arcpy.AddMessage('{} index exists, overwriting...'.format(project_id))
 		arcpy.Delete_management(index_featureclass)
@@ -69,8 +71,8 @@ def updateDAIndex (project_id, study_areas, study_area_indices):
 
 	#arcpy.MakeFeatureLayer_management(study_areas, index_featureclass, where_clause = where)
 	#create feature class from small sewer drainage area and store temporarily in the default gdb
-	arcpy.FeatureClassToFeatureClass_conversion(study_areas, workspace, layer_name, where_clause = where)
+	arcpy.FeatureClassToFeatureClass_conversion(study_areas, tempData, layer_name, where_clause = where)
 	#append temporary feature class to the DA_Master feature class
 	arcpy.Append_management(index_featureclass, study_area_indices, "TEST")
 	#delete the feature class in the default gdb
-	arcpy.Delete_management(index_featureclass)
+	#arcpy.Delete_management(index_featureclass)

--- a/ssha_tools.py
+++ b/ssha_tools.py
@@ -5,7 +5,8 @@ import HHCalculations
 import utils
 import os
 
-default_env = "C:/Users/christine.brown/Desktop/SSHA/Small_Sewer_Capacity/Default.gdb"
+workspace = "C:/Users/christine.brown/Desktop/SSHA/Small_Sewer_Capacity/Default.gdb"
+arcpy.env.workspace = workspace
 
 def trace_upstream(startid, table=r"Small_Sewer_Drainage_Areas",
 					return_field = 'StudyArea_ID',
@@ -57,7 +58,8 @@ def updateDAIndex (project_id, study_areas, study_area_indices):
 	"""
 
 	#check if index already exists, delete if necessary
-	index_featureclass = os.path.join(default_env, "/DA_" + project_id)
+	index_featureclass = os.path.join(workspace, "DA_" + project_id)
+
 	if arcpy.Exists(index_featureclass):
 		arcpy.AddMessage('{} index exists, overwriting...'.format(project_id))
 		arcpy.Delete_management(index_featureclass)
@@ -67,8 +69,8 @@ def updateDAIndex (project_id, study_areas, study_area_indices):
 
 	#arcpy.MakeFeatureLayer_management(study_areas, index_featureclass, where_clause = where)
 	#create feature class from small sewer drainage area and store temporarily in the default gdb
-	arcpy.FeatureClassToFeatureClass_conversion(study_areas, default_env, layer_name, where_clause = where)
+	arcpy.FeatureClassToFeatureClass_conversion(study_areas, workspace, layer_name, where_clause = where)
 	#append temporary feature class to the DA_Master feature class
 	arcpy.Append_management(index_featureclass, study_area_indices, "TEST")
 	#delete the feature class in the default gdb
-	#arcpy.Delete_management(index_featureclass)
+	arcpy.Delete_management(index_featureclass)

--- a/utils.py
+++ b/utils.py
@@ -48,7 +48,7 @@ def match_schemas(matchToTable, editSchemaTable, delete_fields = True):
 		#create list of field names to be added
 		if fieldname not in editFieldsNames:
 			addFieldsList.append(fieldname)
-			arcpy.AddMessage("Add: {}".format(fieldname))
+			#arcpy.AddMessage("Add: {}".format(fieldname))
 
 	#Temp workarond. Remove geometry specific field. Weird bug causes crash when trying to execute arcpy.AddField_management
 	addFieldsList.remove('Shape.STLength()')
@@ -56,7 +56,7 @@ def match_schemas(matchToTable, editSchemaTable, delete_fields = True):
 	for field in arcpy.ListFields(matchToTable):
 		print (field.name + " " + field.type.upper())
 		if field.name in addFieldsList:
-			arcpy.AddMessage("Adding {} + {}".format(field.name, field.type.upper))
+			#arcpy.AddMessage("Adding {} + {}".format(field.name, field.type.upper))
 			arcpy.AddField_management(in_table = editSchemaTable, field_name = field.name, field_type = field.type.upper(), field_length = field.length)
 
 

--- a/utils.py
+++ b/utils.py
@@ -46,14 +46,17 @@ def match_schemas(matchToTable, editSchemaTable, delete_fields = True):
 	addFieldsList = []
 	for fieldname in matchFieldNames:
 		#create list of field names to be added
-		if not fieldname in editFieldsNames:
+		if fieldname not in editFieldsNames:
 			addFieldsList.append(fieldname)
-			print "add: " + fieldname
+			arcpy.AddMessage("Add: {}".format(fieldname))
+
+	#Temp workarond. Remove geometry specific field. Weird bug causes crash when trying to execute arcpy.AddField_management
+	addFieldsList.remove('Shape.STLength()')
 
 	for field in arcpy.ListFields(matchToTable):
-		#print (field.name + " " + field.type.upper())
+		print (field.name + " " + field.type.upper())
 		if field.name in addFieldsList:
-			print ("adding " + field.name + " " + field.type.upper())
+			arcpy.AddMessage("Adding {} + {}".format(field.name, field.type.upper))
 			arcpy.AddField_management(in_table = editSchemaTable, field_name = field.name, field_type = field.type.upper(), field_length = field.length)
 
 


### PR DESCRIPTION
This change came about in an effort to allow multi-user editing through the utilization of an SQL enterprise gdb.  Due to admin permission, creating individual DAIndex feature classes could not be done on a regular basis by users with only "editing" privileges of the enterprise gdb. There, it was necessary to create a MasterDAIndex feature class in the enterprise gdb , create tempDA feature classes in a scratch file gdb (local) and then append the tempDA to the target dataset (the MasterDAIndex). Issues surrounding geometry specific field generation in tempDA arose, and temporary workarounds have been added (deleting fields through arcpy.DeleteField_management as opposed to matching schemas). Return to this issue at a later date with a more sophisticated way of handling schema issues. 